### PR TITLE
Expose bind adress as env var BIND_ADDRESS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v1.2.0 (WIP)
 
+- Added environment var for setting bind address and port. (#11)
+
 - Added endpoint `GET /version` that returns an object of version data of the
   API itself. (#4)
 

--- a/main.go
+++ b/main.go
@@ -53,15 +53,18 @@ func main() {
 	r.GET("/import/gitlab/version", getVersionHandler)
 	r.GET("/import/gitlab/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
-	var bindAddress string
-	var bindAddressDefined bool
-	if bindAddress, bindAddressDefined = os.LookupEnv("BIND_ADDRESS"); !bindAddressDefined {
-		bindAddress = "0.0.0.0:8080"
-	}
-	err := r.Run(bindAddress)
+	err := r.Run(getBindAddress())
 	if err != nil {
 		log.Infof("unable to run gin, error: %+v\n", err)
 	}
+}
+
+func getBindAddress() string {
+	bindAddress, isBindAddressDefined := os.LookupEnv("BIND_ADDRESS")
+	if !isBindAddressDefined || bindAddress == "" {
+		return "0.0.0.0:8080"
+	}
+	return bindAddress
 }
 
 func initLogger(level log.Level) {

--- a/main.go
+++ b/main.go
@@ -53,7 +53,12 @@ func main() {
 	r.GET("/import/gitlab/version", getVersionHandler)
 	r.GET("/import/gitlab/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
-	err := r.Run()
+	var bindAddress string
+	var bindAddressDefined bool
+	if bindAddress, bindAddressDefined = os.LookupEnv("BIND_ADDRESS"); !bindAddressDefined {
+		bindAddress = "0.0.0.0:8080"
+	}
+	err := r.Run(bindAddress)
 	if err != nil {
 		log.Infof("unable to run gin, error: %+v\n", err)
 	}


### PR DESCRIPTION
This allows setting the gin bind adress and port from an environment variable.