### PR TITLE
Added PR template

### DIFF
--- a/.github/.remarkrc
+++ b/.github/.remarkrc
@@ -1,0 +1,15 @@
+{
+    "plugins": [
+        "preset-lint-markdown-style-guide",
+        ["lint-list-item-indent", "space"],
+        ["lint-ordered-list-marker-value", "ordered"],
+        ["lint-no-file-name-irregular-characters", "\\.a-zA-Z0-9-_"],
+        ["stringify", {
+            "bullet": "-",
+            "fences": true,
+            "listItemIndent": "one",
+            "rule": "-"
+        }],
+        ["lint-maximum-line-length", false]
+    ]
+}

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,10 @@
+- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
+  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
+
+## Summary
+
+What did you add, change, or remove, concretely?
+
+## Motivation
+
+What bug or problem does this solve?

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,5 +1,5 @@
-- [ ] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
-- [ ] I've added the `release` label to this PR
+- \[ ] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
+- \[ ] I've added the `release` label to this PR
 
 ## Changes
 

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,11 @@
+- [ ] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
+- [ ] I've added the `release` label to this PR
+
+## Changes
+
+Paste in the respective changes from `CHANGELOG.md`
+
+## Actions after merge
+
+Follow the step-by-step guide found here:
+<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "scripts": {
     "lint": "\"$npm_execpath\" run lint-md && \"$npm_execpath\" run lint-go",
     "lint-fix": "\"$npm_execpath\" run lint-md-fix",
-    "lint-md": "remark .",
-    "lint-md-fix": "remark . -o",
+    "lint-md": "remark . .github",
+    "lint-md-fix": "remark . .github -o",
     "lint-go": "revive -formatter stylish -config revive.toml ./..."
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Basic template that users can select for all new PRs.

> ~~Named it `.github/pull_request_template.md` (according to https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) instead of something like `.github/PULL_REQUEST_TEMPLATES/feature.md` as we don't have a need for multiple PR templates right now.~~

**Edit**: Changed my mind and instead went for two separate templates for this repository.

**Edit 2:** Also added custom `.remarkrc` that's identical to the root one but it has no limit on line length, as GitHub PRs and issues treat newlines differently than regular markdown files

I will add PRs to add this to the other repos once this has been merged.

## Motivation

I've stumbled on this too many times now and forgotten to add the "what?" and "why?" to the PR descriptions, as @fredx30 has so kindly pointed out [many](https://github.com/iver-wharf/wharf-core/pull/11#pullrequestreview-703938958) [times](https://github.com/iver-wharf/wharf-web/pull/46#pullrequestreview-703911622) [before](https://github.com/iver-wharf/wharf-core/pull/10#pullrequestreview-690739043)
