### PR TITLE
Added Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Changed to return IETF RFC-7807 compatible problem responses on failures
   instead of solely JSON-formatted strings. (#15)
 
+- Added Makefile to simplify building and developing the project locally. (#21)
+
 ## v1.2.0 (2021-07-12)
 
 - Added environment var for setting bind address and port. (#11)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,39 @@
 FROM golang:1.16.5 AS build
 WORKDIR /src
 ENV GO111MODULE=on
+
 RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.0
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . /src
 ARG BUILD_VERSION="local docker"
 ARG BUILD_GIT_COMMIT="HEAD"
 ARG BUILD_REF="0"
 RUN deploy/update-version.sh version.yaml \
-		&& swag init --parseDependency --parseDepth 1 \
-		&& go get -t -d \
+		&& make swag \
 		&& CGO_ENABLED=0 go build -o main \
-		&& go test -v
+		&& make test
 
 FROM alpine:3.14.0 AS final
 RUN apk add --no-cache ca-certificates
 WORKDIR /app
 COPY --from=build /src/main ./
 ENTRYPOINT ["/app/main"]
+
+ARG BUILD_VERSION
+ARG BUILD_GIT_COMMIT
+ARG BUILD_REF
+ARG BUILD_DATE
+# The added labels are based on this: https://github.com/projectatomic/ContainerApplicationGenericLabels
+LABEL name="iver-wharf/wharf-provider-gitlab" \
+    url="https://github.com/iver-wharf/wharf-provider-gitlab" \
+    release=${BUILD_REF} \
+    build-date=${BUILD_DATE} \
+    vendor="Iver" \
+    version=${BUILD_VERSION} \
+    vcs-type="git" \
+    vcs-url="https://github.com/iver-wharf/wharf-provider-gitlab" \
+    vcs-ref=${BUILD_GIT_COMMIT} \
+    changelog-url="https://github.com/iver-wharf/wharf-provider-gitlab/blob/${BUILD_VERSION}/CHANGELOG.md" \
+    authoritative-source-url="quay.io"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+commit = $(shell git rev-parse HEAD)
+version = latest
+
+build: swag
+	go build .
+	@echo "Built binary found at ./wharf-provider-gitlab or ./wharf-provider-gitlab.exe"
+
+test: swag
+	go test ./
+
+docker:
+	@echo docker build . \
+		-t "quay.io/iver-wharf/wharf-provider-gitlab:latest" \
+		-t "quay.io/iver-wharf/wharf-provider-gitlab:$(version)" \
+		--build-arg BUILD_VERSION="$(version)" \
+		--build-arg BUILD_GIT_COMMIT="$(commit)" \
+		--build-arg BUILD_DATE="$(shell date --iso-8601=seconds)"
+	@echo ""
+	@echo "Push the image by running:"
+	@echo "docker push quay.io/iver-wharf/wharf-provider-gitlab:latest"
+ifneq "$(version)" "latest"
+	@echo "docker push quay.io/iver-wharf/wharf-provider-gitlab:$(version)"
+endif
+
+docker-run:
+	docker run --rm -it quay.io/iver-wharf/wharf-provider-gitlab:$(version)
+
+serve: swag
+	go run .
+
+swag:
+	swag init --parseDependency --parseDepth 2
+
+deps:
+	cd .. && go get -u github.com/swaggo/swag
+	go mod download

--- a/README.md
+++ b/README.md
@@ -19,31 +19,49 @@ gitlab.com is not well tested.
 
 ## Development
 
-1. Install Go 1.13 or later: <https://golang.org/>
+1. Install Go 1.16 or later: <https://golang.org/>
 
-2. Install the [swaggo/swag](https://github.com/swaggo/swag) CLI globally:
+2. Install dependencies using [GNU Make](https://www.gnu.org/software/make/) or 
+   [GNUWin32](http://gnuwin32.sourceforge.net/install.html)
 
-   ```sh
-   # Run this outside of any Go module, including this repository, to not
-   # have `go get` update the go.mod file.
-   $ cd ..
-
-   $ go get -u github.com/swaggo/swag
+   ```console
+   $ make deps
    ```
 
-3. Generate the swaggo files (this has to be redone each time the swaggo
+3. Generate the Swagger files (this has to be redone each time the swaggo
    documentation comments has been altered):
 
-   ```sh
-   # Navigate back to this repository
-   $ cd wharf-provider-github
-
-   # Generate the files into docs/
-   $ swag init --parseDependency --parseDepth 1
+   ```console
+   $ make swag
    ```
 
 4. Start hacking with your favorite tool. For example VS Code, GoLand,
    Vim, Emacs, or whatnot.
+
+## Releasing
+
+Replace the "v2.0.0" in `make docker version=v2.0.0` with the new version. Full
+documentation can be found at [Releasing a new version](https://iver-wharf.github.io/#/development/releasing-a-new-version).
+
+Below are just how to create the Docker images using [GNU Make](https://www.gnu.org/software/make/)
+or [GNUWin32](http://gnuwin32.sourceforge.net/install.html):
+
+```console
+$ make docker version=v2.0.0
+STEP 1: FROM golang:1.16.5 AS build
+STEP 2: WORKDIR /src
+--> Using cache de3476fd68836750f453d9d4e7b592549fa924c14e68c9b80069881de8aacc9b
+--> de3476fd688
+STEP 3: ENV GO111MODULE=on
+--> Using cache 4f47a95d0642dcaf5525ee1f19113f97911b1254889c5f2ce29eb6f034bd550b
+--> 4f47a95d064
+STEP 4: RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.0
+...
+
+Push the image by running:
+docker push quay.io/iver-wharf/wharf-provider-gitlab:latest
+docker push quay.io/iver-wharf/wharf-provider-gitlab:v2.0.0
+```
 
 ## Linting Golang
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Updated Dockerfile with labels based on https://github.com/projectatomic/ContainerApplicationGenericLabels
- Updated Dockerfile to abuse Docker layer caching for go.mod & go.sum files
- Added Makefile and moved some dependency downloading and Swagger generation over there, as well as Docker build command

## Motivation

Fulfilling what was started in iver-wharf/wharf-provider-github#24:

> This will simplify things so we just keep track of having to do make swag instead of all the --parseDependency --parseDepth stuff.
> 
> Also, some of the Dockerfile changes makes it so the build uses the Docker cache more efficiently, leading to faster consequitive builds.
> 
> The added labels are based on this: https://github.com/projectatomic/ContainerApplicationGenericLabels They are recommended by ProjectAtomic, which develop a lot of cool stuff such as the containerd and runc tools.
