### PR TITLE
Fixed Makefile docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Changed to return IETF RFC-7807 compatible problem responses on failures
   instead of solely JSON-formatted strings. (#15)
 
-- Added Makefile to simplify building and developing the project locally. (#21)
+- Added Makefile to simplify building and developing the project locally.
+  (#21, #22)
 
 ## v1.2.0 (2021-07-12)
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: swag
 	go test ./
 
 docker:
-	@echo docker build . \
+	docker build . \
 		-t "quay.io/iver-wharf/wharf-provider-gitlab:latest" \
 		-t "quay.io/iver-wharf/wharf-provider-gitlab:$(version)" \
 		--build-arg BUILD_VERSION="$(version)" \


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- `make docker` only echo'd `docker build` and did not actually run it. Technically called a "boo boo" from my end.

It did go through review, so I mean, we're all to blame :)
