### PR TITLE
Added docs to types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added Makefile to simplify building and developing the project locally.
   (#21, #22)
 
+- Added documentation to the remaining exported types. (#24)
+
 ## v1.2.0 (2021-07-12)
 
 - Added environment var for setting bind address and port. (#11)

--- a/event.go
+++ b/event.go
@@ -1,28 +1,30 @@
 package main
 
-type Change struct {
-	Before string `json:"before"`
-	After  string `json:"after"`
-	Ref    string `json:"ref"`
-}
-
-type Project struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	URL         string `json:"url"`
-	SSHURL      string `json:"ssh_url"`
-	Namespace   string `json:"namespace"`
-}
-
+// RepositoryUpdateEvent is the event type name for a GitLab repository update
+// event.
 const RepositoryUpdateEvent = "repository_update"
 
+// RepositoryUpdate is a type of event regarding an update to a GitLab
+// repository.
 type RepositoryUpdate struct {
-	Name    string   `json:"event_name"`
-	Project Project  `json:"project"`
-	Changes []Change `json:"changes"`
-	Refs    []string `json:"refs"`
+	Name    string `json:"event_name"`
+	Project struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		URL         string `json:"url"`
+		SSHURL      string `json:"ssh_url"`
+		Namespace   string `json:"namespace"`
+	} `json:"project"`
+	Changes []struct {
+		Before string `json:"before"`
+		After  string `json:"after"`
+		Ref    string `json:"ref"`
+	} `json:"changes"`
+	Refs []string `json:"refs"`
 }
 
+// Event is the base event type, used to figure out what event type the message
+// holds.
 type Event struct {
 	Name string `json:"event_name"`
 }

--- a/importextensions.go
+++ b/importextensions.go
@@ -1,5 +1,6 @@
 package main
 
+// Import is the data that is required by the import endpoint.
 type Import struct {
 	// used in refresh only
 	TokenID   uint   `json:"tokenId" example:"0"`

--- a/testdoubles/wharfclientapifetcher_mock.go
+++ b/testdoubles/wharfclientapifetcher_mock.go
@@ -5,44 +5,60 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// WharfClientAPIFetcherMock is a mock variant of the wharfapi.Client with the
+// helps of github.com/stretchr/testify/mock.
 type WharfClientAPIFetcherMock struct {
 	mock.Mock
 }
 
+// GetTokenById returns a token as identified by its ID.
 func (m *WharfClientAPIFetcherMock) GetTokenById(tokenID uint) (wharfapi.Token, error) {
 	args := m.Called(tokenID)
 	return args.Get(0).(wharfapi.Token), args.Error(1)
 }
 
-func (m *WharfClientAPIFetcherMock) GetToken(token string, userName string) (wharfapi.Token, error) {
+// GetToken returns a token as identified by its token and username strings.
+func (m *WharfClientAPIFetcherMock) GetToken(token, userName string) (wharfapi.Token, error) {
 	args := m.Called(token, userName)
 	return args.Get(0).(wharfapi.Token), args.Error(1)
 }
 
+// PostToken creates a new token and returns the created token,
+// populated with its newly assigned ID.
 func (m *WharfClientAPIFetcherMock) PostToken(token wharfapi.Token) (wharfapi.Token, error) {
 	args := m.Called(token)
 	return args.Get(0).(wharfapi.Token), args.Error(1)
 }
 
+// GetProviderById returns a provider as identified by its ID.
 func (m *WharfClientAPIFetcherMock) GetProviderById(providerID uint) (wharfapi.Provider, error) {
 	args := m.Called(providerID)
 	return args.Get(0).(wharfapi.Provider), args.Error(1)
 }
 
-func (m *WharfClientAPIFetcherMock) GetProvider(providerName string, URLStr string, uploadURLStr string, tokenID uint) (wharfapi.Provider, error) {
-	args := m.Called(providerName, URLStr, uploadURLStr, tokenID)
+// GetProvider returns a provider as identified by its name, URL, and upload
+// URL strings, as well as its token ID reference.
+func (m *WharfClientAPIFetcherMock) GetProvider(providerName, urlStr, uploadURLStr string, tokenID uint) (wharfapi.Provider, error) {
+	args := m.Called(providerName, urlStr, uploadURLStr, tokenID)
 	return args.Get(0).(wharfapi.Provider), args.Error(1)
 }
 
+// PostProvider creates a new provider and returns the created provider,
+// populated with its newly assigned ID.
 func (m *WharfClientAPIFetcherMock) PostProvider(provider wharfapi.Provider) (wharfapi.Provider, error) {
 	args := m.Called(provider)
 	return args.Get(0).(wharfapi.Provider), args.Error(1)
 }
 
+// PutProject creates or updates a project, based on wether the project ID value
+// is non-zero, and returns the created or updated project,
+// populated with its possibly newly assigned ID.
 func (m *WharfClientAPIFetcherMock) PutProject(project wharfapi.Project) (wharfapi.Project, error) {
 	args := m.Called(project)
 	return args.Get(0).(wharfapi.Project), args.Error(1)
 }
+
+// PutBranches resets the list of branches for a project.
 func (m *WharfClientAPIFetcherMock) PutBranches(branches []wharfapi.Branch) ([]wharfapi.Branch, error) {
 	args := m.Called(branches)
 	return args.Get(0).([]wharfapi.Branch), args.Error(1)

--- a/testdoubles/wharfclientapifetcher_mock.go
+++ b/testdoubles/wharfclientapifetcher_mock.go
@@ -58,7 +58,7 @@ func (m *WharfClientAPIFetcherMock) PutProject(project wharfapi.Project) (wharfa
 	return args.Get(0).(wharfapi.Project), args.Error(1)
 }
 
-// PutBranches resets the list of branches for a project.
+// PutBranches replaces the list of branches for a project.
 func (m *WharfClientAPIFetcherMock) PutBranches(branches []wharfapi.Branch) ([]wharfapi.Branch, error) {
 	args := m.Called(branches)
 	return args.Get(0).([]wharfapi.Branch), args.Error(1)

--- a/testdoubles/wharfclientapifetcher_mock.go
+++ b/testdoubles/wharfclientapifetcher_mock.go
@@ -6,7 +6,7 @@ import (
 )
 
 // WharfClientAPIFetcherMock is a mock variant of the wharfapi.Client with the
-// helps of github.com/stretchr/testify/mock.
+// help of github.com/stretchr/testify/mock.
 type WharfClientAPIFetcherMock struct {
 	mock.Mock
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added comments to exported types
- Embedded some event types as they were not used as standalone

## Motivation

To begone with all linting issues.

Remaining linting issues:

```console
$ npm run lint-go
testdoubles/wharfclientapifetcher_mock.go
  (15, 37)  https://revive.run/r#var-naming  method GetTokenById should be GetTokenByID
  (34, 37)  https://revive.run/r#var-naming  method GetProviderById should be GetProviderByID

trigger.go
  (25, 1)  https://revive.run/r#exported  exported function RunRepositoryUpdateTrigger should have comment or be unexported


 ✖ 3 problems (0 errors) (3 warnings)
```

The `wharfclientapifetcher_mock.go` ones are out of our control, as those names actually comes from the wharfapi package inside the wharf-api-client-go repo. Update for that is on its way, but until then this is left as-is.

The `trigger.go` one [is about to be removed](https://github.com/iver-wharf/wharf-provider-gitlab/pull/23/files?file-filters%5B%5D=.go&file-filters%5B%5D=.md&file-filters%5B%5D=.mod&file-filters%5B%5D=No+extension#diff-9514899a184e311b13008f9193e5c94b6bef777f168ab11290ed85f90ba1b418) in #23, so I'm leaving it out in this one.
