### PR TITLE
Updated wharf-api-client-go to v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added documentation to the remaining exported types. (#24)
 
+- Changed version of `github.com/iver-wharf/wharf-api-client-go`
+  from v1.2.0 -> v1.3.1. (#26)
+
 ## v1.2.0 (2021-07-12)
 
 - Added environment var for setting bind address and port. (#11)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.7.1
 	github.com/go-openapi/spec v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.6 // indirect
-	github.com/iver-wharf/wharf-api-client-go v1.2.0
+	github.com/iver-wharf/wharf-api-client-go v1.3.1
 	github.com/iver-wharf/wharf-core v1.1.0
 	github.com/mailru/easyjson v0.7.0 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iver-wharf/wharf-api-client-go v1.2.0 h1:QQt/zSUXsM2mZwDy6uNQF+tFEY0X6qb+7BzixriPduA=
-github.com/iver-wharf/wharf-api-client-go v1.2.0/go.mod h1:IzhUU97bwsz3ZF1N4X8AM51Wca41HSVC5G56q3wDZDA=
+github.com/iver-wharf/wharf-api-client-go v1.3.1 h1:R3gol3x1iHT1boZf/J0YqB1ml4SEJEVllZ6rk3gyTPU=
+github.com/iver-wharf/wharf-api-client-go v1.3.1/go.mod h1:nv5UChpadYGVvsHhfSw4ss7cOFoTiAJWejzZ+7/23cg=
 github.com/iver-wharf/wharf-core v1.1.0 h1:vdjW+A8p0GBBcd1sB3vKwpN44t0dBrYfpY+B6ebSMbI=
 github.com/iver-wharf/wharf-core v1.1.0/go.mod h1:dpYtdL52i17Aue7An6mJL9dICeulBDsGZO/PxZYHgrE=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
@@ -404,8 +404,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
-github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
@@ -573,7 +571,6 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/import.go
+++ b/import.go
@@ -42,7 +42,7 @@ func (m importModule) runGitLabHandler(c *gin.Context) {
 
 	wharfClient := wharfapi.Client{
 		AuthHeader: c.GetHeader("Authorization"),
-		ApiUrl:     m.config.API.URL,
+		APIURL:     m.config.API.URL,
 	}
 
 	importer, ok := newGitLabImporterWritesProblem(c, wharfClient, &i)
@@ -109,7 +109,7 @@ func newGitLabImporterWritesProblem(c *gin.Context, wharfClient wharfapi.Client,
 
 func obtainTokenWritesProblem(c *gin.Context, wharfClient wharfapi.Client, importData *Import) (wharfapi.Token, bool) {
 	if importData.TokenID != 0 {
-		token, err := wharfClient.GetTokenById(importData.TokenID)
+		token, err := wharfClient.GetTokenByID(importData.TokenID)
 		if err != nil {
 			ginutil.WriteAPIClientReadError(c, err,
 				fmt.Sprintf(
@@ -150,7 +150,7 @@ func obtainTokenWritesProblem(c *gin.Context, wharfClient wharfapi.Client, impor
 
 func obtainProviderWritesProblem(c *gin.Context, wharfClient wharfapi.Client, tokenID uint, importData *Import) (wharfapi.Provider, bool) {
 	if importData.ProviderID != 0 {
-		provider, err := wharfClient.GetProviderById(importData.ProviderID)
+		provider, err := wharfClient.GetProviderByID(importData.ProviderID)
 		if err != nil || provider.ProviderID == 0 {
 			ginutil.WriteAPIClientReadError(c, err,
 				fmt.Sprintf("Unable to get provider by ID %d.", importData.ProjectID))

--- a/import_test.go
+++ b/import_test.go
@@ -72,7 +72,7 @@ func (suite *importTestSuite) SetupSuite() {
 				proj.GroupName == wProj.GroupName &&
 				proj.Name == wProj.Name &&
 				proj.GitURL == wProj.GitURL &&
-				proj.AvatarUrl == wProj.AvatarUrl &&
+				proj.AvatarURL == wProj.AvatarURL &&
 				proj.Description == wProj.Description &&
 				proj.BuildDefinition == wProj.BuildDefinition
 		})).Return(wProj, nil)
@@ -166,7 +166,7 @@ func mapToWharfProj(proj *gitlab.Project, tokenID uint, providerID uint) wharfap
 		TokenID:         tokenID,
 		Description:     proj.Description,
 		BuildDefinition: "",
-		AvatarUrl:       proj.AvatarURL,
+		AvatarURL:       proj.AvatarURL,
 		GitURL:          proj.SSHURLToRepo,
 	}
 }

--- a/iwharfclientfetcher.go
+++ b/iwharfclientfetcher.go
@@ -3,10 +3,10 @@ package main
 import "github.com/iver-wharf/wharf-api-client-go/pkg/wharfapi"
 
 type wharfClientAPIFetcher interface {
-	GetTokenById(tokenID uint) (wharfapi.Token, error)
+	GetTokenByID(tokenID uint) (wharfapi.Token, error)
 	GetToken(token string, userName string) (wharfapi.Token, error)
 	PostToken(token wharfapi.Token) (wharfapi.Token, error)
-	GetProviderById(providerID uint) (wharfapi.Provider, error)
+	GetProviderByID(providerID uint) (wharfapi.Provider, error)
 	GetProvider(providerName string, urlStr string, uploadURLStr string, tokenID uint) (wharfapi.Provider, error)
 	PostProvider(provider wharfapi.Provider) (wharfapi.Provider, error)
 	PutProject(project wharfapi.Project) (wharfapi.Project, error)

--- a/mapper.go
+++ b/mapper.go
@@ -21,7 +21,7 @@ func (m *mapper) mapProjectToWharfEntity(proj gitlab.Project, buildDef string) w
 		Name:            proj.Name,
 		BuildDefinition: buildDef,
 		Description:     proj.Description,
-		AvatarUrl:       proj.AvatarURL,
+		AvatarURL:       proj.AvatarURL,
 		GitURL:          proj.SSHURLToRepo,
 		TokenID:         m.tokenID,
 		ProviderID:      m.providerID,

--- a/testdoubles/wharfclientapifetcher_mock.go
+++ b/testdoubles/wharfclientapifetcher_mock.go
@@ -11,8 +11,8 @@ type WharfClientAPIFetcherMock struct {
 	mock.Mock
 }
 
-// GetTokenById returns a token as identified by its ID.
-func (m *WharfClientAPIFetcherMock) GetTokenById(tokenID uint) (wharfapi.Token, error) {
+// GetTokenByID returns a token as identified by its ID.
+func (m *WharfClientAPIFetcherMock) GetTokenByID(tokenID uint) (wharfapi.Token, error) {
 	args := m.Called(tokenID)
 	return args.Get(0).(wharfapi.Token), args.Error(1)
 }
@@ -30,8 +30,8 @@ func (m *WharfClientAPIFetcherMock) PostToken(token wharfapi.Token) (wharfapi.To
 	return args.Get(0).(wharfapi.Token), args.Error(1)
 }
 
-// GetProviderById returns a provider as identified by its ID.
-func (m *WharfClientAPIFetcherMock) GetProviderById(providerID uint) (wharfapi.Provider, error) {
+// GetProviderByID returns a provider as identified by its ID.
+func (m *WharfClientAPIFetcherMock) GetProviderByID(providerID uint) (wharfapi.Provider, error) {
 	args := m.Called(providerID)
 	return args.Get(0).(wharfapi.Provider), args.Error(1)
 }

--- a/trigger.go
+++ b/trigger.go
@@ -14,9 +14,5 @@ func runGitLabTriggerHandler(c *gin.Context) {
 	}
 	log.Info().WithString("event", event.Name).Message("Successfully binded event.")
 
-	if event.Name == RepositoryUpdateEvent {
-		// TODO
-	}
-
 	log.Debug().Message("GitLab trigger finished.")
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Ran

  ```console
  $ go get github.com/iver-wharf/wharf-api-client-go@v1.3.1
  ```

- Updated some method and field names as they got renamed in wharf-api-client-go v1.2.0 &rarr; v1.3.0

- Removed empty code block, as that was a linting warning

## Motivation

Keep the repos up to date, and begone with linting warnings

Before:

```console
$ npm run lint-go

> @ lint-go /home/kalle/dev/wharf/wharf-provider-gitlab
> revive -formatter stylish -config revive.toml ./...

testdoubles/wharfclientapifetcher_mock.go
  (15, 37)  https://revive.run/r#var-naming  method GetTokenById should be GetTokenByID
  (34, 37)  https://revive.run/r#var-naming  method GetProviderById should be GetProviderByID

trigger.go
  (17, 41)  https://revive.run/r#empty-block  this block is empty, you can remove it


 ✖ 3 problems (0 errors) (3 warnings)

```

Now, after this PR:

```console
$ npm run lint-go

> @ lint-go /home/kalle/dev/wharf/wharf-provider-gitlab
> revive -formatter stylish -config revive.toml ./...

```
