### PR TITLE
Added "--pull" to docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ test: swag
 
 docker:
 	docker build . \
+		--pull \
 		-t "quay.io/iver-wharf/wharf-provider-gitlab:latest" \
 		-t "quay.io/iver-wharf/wharf-provider-gitlab:$(version)" \
 		--build-arg BUILD_VERSION="$(version)" \


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added `--pull` to `docker build` in `Makefile`

## Motivation

This forces the docker build to always try and pull the latest image, so that our local cache doesn't make our newly-built images use old base images.

[The `--pull` flag](https://docs.docker.com/engine/reference/commandline/build/#:~:text=--pull) does not disable the cache. Docker will first check the hashes of the upstream image layers, and only if they don't match with the cached layers then it will start downloading the up-to-date layers.

This was brought up in a PR discussion: https://github.com/iver-wharf/wharf-web/pull/66#discussion_r706091268

---

Skipping adding to CHANGELOG.md as this is such a minor change.
