### PR TITLE
Removed UploadURL references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - Alpine: 3.14.0 -> 3.14 (#28)
   - Golang: 1.16.5 -> 1.16 (#28)
 
+- Removed `UploadURL` field from the `Import` struct, and all references to
+  `wharfapi.Provider.UploadURL`, which will be removed in wharf-api v5.0.0 as it
+  did not provide any functionality. (#30)
+
 ## v1.2.0 (2021-07-12)
 
 - Added environment var for setting bind address and port. (#11)

--- a/importextensions.go
+++ b/importextensions.go
@@ -3,11 +3,10 @@ package main
 // Import is the data that is required by the import endpoint.
 type Import struct {
 	// used in refresh only
-	TokenID   uint   `json:"tokenId" example:"0"`
-	Token     string `json:"token" example:"sample token"`
-	User      string `json:"user" example:"sample user name"`
-	URL       string `json:"url" example:"https://gitlab.local"`
-	UploadURL string `json:"uploadUrl" example:""`
+	TokenID uint   `json:"tokenId" example:"0"`
+	Token   string `json:"token" example:"sample token"`
+	User    string `json:"user" example:"sample user name"`
+	URL     string `json:"url" example:"https://gitlab.local"`
 	// used in refresh only
 	ProviderID uint `json:"providerId" example:"0"`
 	// used in refresh only

--- a/importextensions_test.go
+++ b/importextensions_test.go
@@ -86,7 +86,6 @@ func getTestImport() Import {
 		Token:      "sample token",
 		User:       "sample user name",
 		URL:        "https://sth.com",
-		UploadURL:  "",
 		ProviderID: 1,
 		ProjectID:  88,
 		Project:    "sample project name",

--- a/iwharfclientfetcher.go
+++ b/iwharfclientfetcher.go
@@ -7,7 +7,7 @@ type wharfClientAPIFetcher interface {
 	GetToken(token string, userName string) (wharfapi.Token, error)
 	PostToken(token wharfapi.Token) (wharfapi.Token, error)
 	GetProviderByID(providerID uint) (wharfapi.Provider, error)
-	GetProvider(providerName string, urlStr string, uploadURLStr string, tokenID uint) (wharfapi.Provider, error)
+	GetProvider(providerName, urlStr string, tokenID uint) (wharfapi.Provider, error)
 	PostProvider(provider wharfapi.Provider) (wharfapi.Provider, error)
 	PutProject(project wharfapi.Project) (wharfapi.Project, error)
 	PutBranches(branches []wharfapi.Branch) ([]wharfapi.Branch, error)

--- a/testdoubles/wharfclientapifetcher_mock.go
+++ b/testdoubles/wharfclientapifetcher_mock.go
@@ -38,8 +38,8 @@ func (m *WharfClientAPIFetcherMock) GetProviderByID(providerID uint) (wharfapi.P
 
 // GetProvider returns a provider as identified by its name, URL, and upload
 // URL strings, as well as its token ID reference.
-func (m *WharfClientAPIFetcherMock) GetProvider(providerName, urlStr, uploadURLStr string, tokenID uint) (wharfapi.Provider, error) {
-	args := m.Called(providerName, urlStr, uploadURLStr, tokenID)
+func (m *WharfClientAPIFetcherMock) GetProvider(providerName, urlStr string, tokenID uint) (wharfapi.Provider, error) {
+	args := m.Called(providerName, urlStr, tokenID)
 	return args.Get(0).(wharfapi.Provider), args.Error(1)
 }
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

- \[x] Wait for new release of wharf-api, with iver-wharf/wharf-api#82

- \[x] Wait for new release of wharf-api-client-go, with iver-wharf/wharf-api-client-go#21.

## Summary

Removed `UploadURL` field from the `Import` struct.
Removed any reference to `wharfapi.Provider.UploadURL`.

## Motivation

These fields did not provide any functionality and were thus effectively just bloat.

Required change to be compatible with iver-wharf/wharf-api-client-go#21

Part of inter-repo change, together with:
- iver-wharf/wharf-api#82
- iver-wharf/wharf-api-client-go#21
- iver-wharf/wharf-provider-github#35
- iver-wharf/wharf-provider-azuredevops#39

--
Closes #27
