### PR TITLE
Fix windows docker build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Handle line endings for docker scripts on Windows
+*.sh text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - Alpine: 3.14.0 -> 3.14 (#28)
   - Golang: 1.16.5 -> 1.16 (#28)
 
+- Changed docker-build scripts for easier windows building. (#39)
+
 ## v1.2.0 (2021-07-12)
 
 - Added environment var for setting bind address and port. (#11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - Alpine: 3.14.0 -> 3.14 (#28)
   - Golang: 1.16.5 -> 1.16 (#28)
 
-- Changed docker-build scripts for easier windows building. (#39)
+- Changed Dockerfile for easier windows building. (#39)
 
 ## v1.2.0 (2021-07-12)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ ARG BUILD_REF="0"
 ARG BUILD_DATE=""
 RUN chmod +x deploy/update-version.sh  \
         && deploy/update-version.sh version.yaml \
-		&& make swag \
-		&& CGO_ENABLED=0 go build -o main \
-		&& make test
+        && make swag \
+        && CGO_ENABLED=0 go build -o main \
+        && make test
 
 ARG REG=docker.io
 FROM ${REG}/library/alpine:3.14 AS final

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ ARG BUILD_GIT_COMMIT="HEAD"
 ARG BUILD_REF="0"
 ARG BUILD_DATE=""
 RUN chmod +x deploy/update-version.sh  \
-        && deploy/update-version.sh version.yaml \
-        && make swag \
-        && CGO_ENABLED=0 go build -o main \
-        && make test
+    && deploy/update-version.sh version.yaml \
+    && make swag \
+    && CGO_ENABLED=0 go build -o main \
+    && make test
 
 ARG REG=docker.io
 FROM ${REG}/library/alpine:3.14 AS final

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ ARG BUILD_VERSION="local docker"
 ARG BUILD_GIT_COMMIT="HEAD"
 ARG BUILD_REF="0"
 ARG BUILD_DATE=""
-RUN deploy/update-version.sh version.yaml \
+RUN chmod +x deploy/update-version.sh  \
+        && deploy/update-version.sh version.yaml \
 		&& make swag \
 		&& CGO_ENABLED=0 go build -o main \
 		&& make test

--- a/deploy/update-version.sh
+++ b/deploy/update-version.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 VERSION_FILE="${1:?'Version file must be provided'}"
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Shebang signature modified for docker runs. Had issues on docker windows.

## Motivation

This makes it easier to docker build on windows.

Also see similar changes:
- https://github.com/iver-wharf/wharf-web/pull/95
- https://github.com/iver-wharf/wharf-provider-azuredevops/pull/48
- https://github.com/iver-wharf/wharf-provider-github/pull/44
- https://github.com/iver-wharf/wharf-provider-gitlab/pull/39
- https://github.com/iver-wharf/wharf-api/pull/126