### PR TITLE
Fixed project subpath matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Changed Dockerfile for easier windows building. (#39)
 
+- Fixed projects failing to import when a different GitLab repository began
+  with the same name (#3), eg. `myGroup/myRepo` and `myGroup/myRepo2`. (#40)
+
 ## v1.2.0 (2021-07-12)
 
 - Added environment var for setting bind address and port. (#11)

--- a/gitlab.go
+++ b/gitlab.go
@@ -59,15 +59,22 @@ func (client *gitLabClient) getProject(groupName string, projectName string) (*g
 		return nil, err
 	}
 
-	if len(projects) == 1 {
-		return projects[0], nil
+	var filteredProjects []*gitlab.Project
+	for _, p := range projects {
+		if p.Name == projectName || p.Path == projectName {
+			filteredProjects = append(filteredProjects, p)
+		}
 	}
 
-	log.Info().WithInt("projectCount", len(projects)).
+	if len(filteredProjects) == 1 {
+		return filteredProjects[0], nil
+	}
+
+	log.Info().WithInt("projectCount", len(filteredProjects)).
 		WithStringf("project", "%s/%s", groupName, projectName).
 		Message("Invalid projects count.")
 
-	return nil, fmt.Errorf("unable to get project %v/%v", groupName, projectName)
+	return nil, fmt.Errorf("project search %v/%v matched multiple projects", groupName, projectName)
 }
 
 func (client *gitLabClient) listProjectsFromGroup(groupName string, page int) ([]*gitlab.Project, gitLabPaging, error) {

--- a/gitlab.go
+++ b/gitlab.go
@@ -74,7 +74,7 @@ func (client *gitLabClient) getProject(groupName string, projectName string) (*g
 		WithStringf("project", "%s/%s", groupName, projectName).
 		Message("Invalid projects count.")
 
-	return nil, fmt.Errorf("project search %v/%v matched multiple projects", groupName, projectName)
+	return nil, fmt.Errorf("project search %v/%v did not match 1 project, but %d", groupName, projectName, len(filteredProjects))
 }
 
 func (client *gitLabClient) listProjectsFromGroup(groupName string, page int) ([]*gitlab.Project, gitLabPaging, error) {


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added additional filtering in `gitLabClient.getProject()` so it doesn't get confused by subpath projects.

## Motivation

Closes #3
