### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v2.0.0 (WIP)
+## v2.0.0 (2022-05-10)
 
 - BREAKING: Removed support for `github.com/iver-wharf/wharf-api` v4.
   Now requires a minimum of wharf-api v5.0.0. (#43)


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- BREAKING: Removed support for `github.com/iver-wharf/wharf-api` v4. Now requires a minimum of wharf-api v5.0.0. (#43)

- Added support for `github.com/iver-wharf/wharf-api` v5.0.0. (#43)

- Changed version of dependencies:

  - `github.com/gin-gonic/gin` from v1.7.4 to v1.7.7 (#46)
  - `github.com/iver-wharf/wharf-api-client-go` from v1.3.1 to v2.0.0 (#26, #43)
  - `github.com/swaggo/gin-swagger` from v1.3.1 to v1.4.3 (#46)
  - `github.com/swaggo/swag` from v1.7.1 to v1.8.1 (#46)

- Added GitLab's internal project ID when adding project to database. (#43)

- Changed Go runtime from v1.16 to v1.18. (#46)

- Changed version of Docker base images:

  - Alpine: 3.14 -> 3.15 (#46)
  - Golang: 1.16 -> 1.18 (#46)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
