### PR TITLE
Release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Changed version of dependencies:
 
-  - `github.com/iver-wharf/wharf-api-client-go` from v2.0.0 to v2.2.0 (#48)
+  - `github.com/iver-wharf/wharf-api-client-go` from v2.0.0 to v2.2.1 (#48)
 
 - Fixed failing project import when importing a single project. (#48)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v2.0.1 (WIP)
+## v2.0.1 (2022-05-10)
 
 - Changed version of dependencies:
 
   - `github.com/iver-wharf/wharf-api-client-go` from v2.0.0 to v2.2.0 (#48)
+
+- Fixed failing project import when importing a single project. (#48)
 
 ## v2.0.0 (2022-05-10)
 


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- Changed version of dependencies:

  - `github.com/iver-wharf/wharf-api-client-go` from v2.0.0 to v2.2.0 (#48)

- Fixed failing project import when importing a single project. (#48)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
